### PR TITLE
Support of JVM options with quotes on Windows and modular Java (>= 9)

### DIFF
--- a/core-feature-pack/src/main/resources/content/bin/add-user.bat
+++ b/core-feature-pack/src/main/resources/content/bin/add-user.bat
@@ -48,7 +48,7 @@ if "x%JAVA_HOME%" == "x" (
 
 rem set default modular jvm parameters
 setlocal EnableDelayedExpansion
-call "!DIRNAME!common.bat" :setDefaultModularJvmOptions "!JAVA_OPTS!"
+call "!DIRNAME!common.bat" :setDefaultModularJvmOptions !JAVA_OPTS!
 set "JAVA_OPTS=!JAVA_OPTS! !DEFAULT_MODULAR_JVM_OPTIONS!"
 setlocal DisableDelayedExpansion
 

--- a/core-feature-pack/src/main/resources/content/bin/common.bat
+++ b/core-feature-pack/src/main/resources/content/bin/common.bat
@@ -9,7 +9,7 @@ goto :eof
 :setDefaultModularJvmOptions
   call :setModularJdk
   if "!MODULAR_JDK!" == "true" (
-    echo "%~1" | findstr /I "\-\-add\-modules" > nul
+    echo %* | findstr /I "\-\-add\-modules" > nul
     if errorlevel == 1 (
       rem Set default modular jdk options
       set "DEFAULT_MODULAR_JVM_OPTIONS=!DEFAULT_MODULAR_JVM_OPTIONS! --add-exports=java.base/sun.nio.ch=ALL-UNNAMED"

--- a/core-feature-pack/src/main/resources/content/bin/domain.bat
+++ b/core-feature-pack/src/main/resources/content/bin/domain.bat
@@ -99,9 +99,9 @@ if "x%JAVA_HOME%" == "x" (
 
 rem set default modular jvm parameters
 setlocal EnableDelayedExpansion
-call "!DIRNAME!common.bat" :setDefaultModularJvmOptions "!PROCESS_CONTROLLER_JAVA_OPTS!"
+call "!DIRNAME!common.bat" :setDefaultModularJvmOptions !PROCESS_CONTROLLER_JAVA_OPTS!
 set "PROCESS_CONTROLLER_JAVA_OPTS=!PROCESS_CONTROLLER_JAVA_OPTS! !DEFAULT_MODULAR_JVM_OPTIONS!"
-call "!DIRNAME!common.bat" :setDefaultModularJvmOptions "!HOST_CONTROLLER_JAVA_OPTS!"
+call "!DIRNAME!common.bat" :setDefaultModularJvmOptions !HOST_CONTROLLER_JAVA_OPTS!
 set "HOST_CONTROLLER_JAVA_OPTS=!HOST_CONTROLLER_JAVA_OPTS! !DEFAULT_MODULAR_JVM_OPTIONS!"
 setlocal DisableDelayedExpansion
 

--- a/core-feature-pack/src/main/resources/content/bin/jboss-cli.bat
+++ b/core-feature-pack/src/main/resources/content/bin/jboss-cli.bat
@@ -52,7 +52,7 @@ if "x%JAVA_HOME%" == "x" (
 
 rem set default modular jvm parameters
 setlocal EnableDelayedExpansion
-call "!DIRNAME!common.bat" :setDefaultModularJvmOptions "!JAVA_OPTS!"
+call "!DIRNAME!common.bat" :setDefaultModularJvmOptions !JAVA_OPTS!
 set "JAVA_OPTS=!JAVA_OPTS! !DEFAULT_MODULAR_JVM_OPTIONS!"
 setlocal DisableDelayedExpansion
 

--- a/core-feature-pack/src/main/resources/content/bin/vault.bat
+++ b/core-feature-pack/src/main/resources/content/bin/vault.bat
@@ -45,7 +45,7 @@ if "x%JAVA_HOME%" == "x" (
 
 rem set default modular jvm parameters
 setlocal EnableDelayedExpansion
-call "!DIRNAME!common.bat" :setDefaultModularJvmOptions "!JAVA_OPTS!"
+call "!DIRNAME!common.bat" :setDefaultModularJvmOptions !JAVA_OPTS!
 set "JAVA_OPTS=!JAVA_OPTS! !DEFAULT_MODULAR_JVM_OPTIONS!"
 setlocal DisableDelayedExpansion
 


### PR DESCRIPTION
When I have these lines in my `$JBOSS_HOME/bin/standalone.conf.bat`:

```
set "JAVA_OPTS=%JAVA_OPTS% "-Xlog:gc*:file=\"C:\Users\user\Desktop\wildfly-test\logs\gc.log\":time,uptime,level,tags:filesize=10M,filecount=5""
set "JAVA_OPTS=%JAVA_OPTS% --add-exports=java.base/sun.nio.ch=ALL-UNNAMED --add-exports=jdk.unsupported/sun.misc=ALL-UNNAMED --add-exports=jdk.unsupported/sun.reflect=ALL-UNNAMED --add-modules=java.se"
```

then I get these JVM options logged by WildFly at start (duplicated `--add-modules` option):

```
  JAVA_OPTS: "-Dprogram.name=standalone.bat -Xms64M -Xmx512M -XX:MetaspaceSize=96M -XX:MaxMetaspaceSize=256m -Djava.net.preferIPv4Stack=true -Djboss.modules.system.pkgs=org.jboss.byteman "-Xlog:gc*:file=\"C:\Users\user\Desktop\wildfly-test\logs\gc.log\":time,uptime,level,tags:filesize=10M,filecount=5" --add-exports=java.base/sun.nio.ch=ALL-UNNAMED --add-exports=jdk.unsupported/sun.misc=ALL-UNNAMED --add-exports=jdk.unsupported/sun.reflect=ALL-UNNAMED --add-modules=java.se  --add-exports=java.base/sun.nio.ch=ALL-UNNAMED --add-exports=jdk.unsupported/sun.misc=ALL-UNNAMED --add-exports=jdk.unsupported/sun.reflect=ALL-UNNAMED --add-modules=java.se"
```

With fixed `$JBOSS_HOME/bin/common.bat` taken from this pull request (and the same `standalone.conf.bat`) I get these JVM options logged by WildFly (expected JVM options):

```
  JAVA_OPTS: "-Dprogram.name=standalone.bat -Xms64M -Xmx512M -XX:MetaspaceSize=96M -XX:MaxMetaspaceSize=256m -Djava.net.preferIPv4Stack=true -Djboss.modules.system.pkgs=org.jboss.byteman "-Xlog:gc*:file=\"C:\Users\user\Desktop\wildfly-test\logs\gc.log\":time,uptime,level,tags:filesize=10M,filecount=5" --add-exports=java.base/sun.nio.ch=ALL-UNNAMED --add-exports=jdk.unsupported/sun.misc=ALL-UNNAMED --add-exports=jdk.unsupported/sun.reflect=ALL-UNNAMED --add-modules=java.se "
```